### PR TITLE
Fix: setup.sh - added --ignore-scripts to npm install

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -119,7 +119,7 @@ cd frontend || exit 1
 # Install npm dependencies
 if [ ! -d "node_modules" ]; then
     print_status "Installing npm dependencies (this may take a few minutes)..."
-    npm install --silent
+    npm install --ignore-scripts --silent
     
     if [ $? -ne 0 ]; then
         print_error "Failed to install npm dependencies"


### PR DESCRIPTION
## Issue: `setup.sh` fails during npm install due to missing `patch-package` command

### Summary
`setup.sh` fails when installing frontend dependencies. The error is caused by `rollup`’s postinstall script invoking `patch-package`, which is not installed and not a project dependency.

### Error message
```
npm ERR! code 127
npm ERR! path /path/to/frontend/node_modules/rollup
npm ERR! command failed
npm ERR! command /bin/bash -c patch-package
npm ERR! /bin/bash: line 1: patch-package: command not found
```

### Root cause
1. `rollup` (4.53.0) has `hasInstallScript: true` in `package-lock.json`.
2. Its postinstall script runs `patch-package`.
3. `patch-package` is not in the project’s dependencies.
4. `setup.sh` runs `npm install` without `--ignore-scripts`, so postinstall scripts execute.
5. The script fails when `patch-package` is not found.