### PR TITLE
Potential fix for code scanning alert no. 2: Uncontrolled command line

### DIFF
--- a/backend/repo_cloner.py
+++ b/backend/repo_cloner.py
@@ -5,7 +5,7 @@ import shutil
 import os
 from typing import Optional, Tuple
 from pathlib import Path
-
+import re
 
 class RepoCloner:
     """Handle cloning and cleanup of repositories."""
@@ -35,6 +35,9 @@ class RepoCloner:
         repo_url = f"https://github.com/{owner}/{repo}.git"
         
         # Use token in URL if provided (for private repos)
+            # Validate token: only allow alphanumeric, underscore, and dash, typical of GitHub tokens (minimum 20, maximum 100 characters for sanity)
+            if not re.fullmatch(r'^[A-Za-z0-9_\-]{20,100}$', token):
+                raise ValueError("Invalid GitHub token format")
         if token:
             # For private repos, use token in URL
             repo_url = f"https://{token}@github.com/{owner}/{repo}.git"


### PR DESCRIPTION
Potential fix for [https://github.com/0xCardinal/actsense/security/code-scanning/2](https://github.com/0xCardinal/actsense/security/code-scanning/2)

To fix this vulnerability, restrict the token value to valid (allowlisted) characters and expected length/format before using it in the git URL. Only allow characters that are known to be allowed in Github tokens (typically alphanumeric and `_`, `-`), and reject any that contain unusual or unsafe characters. 

**Actions:**
- Add validation logic to the top of `clone_repository` (`backend/repo_cloner.py`), ensuring that if `token` is provided it matches a regular expression such as `^[A-Za-z0-9_\-]+$` and optionally ensure a minimum/maximum length (Github tokens are usually at least 40 characters).
- If the token is invalid, raise an exception and abort before constructing `repo_url`.

**Files to change:** Only `backend/repo_cloner.py` needs modification, namely in the `clone_repository` method.  
**Imports required:** Will need to add the `re` module at the top of the file for regex checking.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
