### PR TITLE
Potential fix for code scanning alert no. 5: Uncontrolled data used in path expression

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -405,9 +405,12 @@ if os.path.exists(FRONTEND_BUILD_PATH):
         if full_path.startswith("api/"):
             raise HTTPException(status_code=404, detail="Not found")
         
-        file_path = os.path.join(FRONTEND_BUILD_PATH, full_path)
-        if os.path.exists(file_path) and os.path.isfile(file_path):
-            return FileResponse(file_path)
+        # Normalize and check the path is within FRONTEND_BUILD_PATH
+        abs_frontend_root = os.path.abspath(FRONTEND_BUILD_PATH)
+        file_path = os.path.normpath(os.path.join(FRONTEND_BUILD_PATH, full_path))
+        abs_file_path = os.path.abspath(file_path)
+        if abs_file_path.startswith(abs_frontend_root) and os.path.exists(abs_file_path) and os.path.isfile(abs_file_path):
+            return FileResponse(abs_file_path)
         # Serve index.html for SPA routing
         return FileResponse(os.path.join(FRONTEND_BUILD_PATH, "index.html"))
 


### PR DESCRIPTION
Potential fix for [https://github.com/0xCardinal/actsense/security/code-scanning/5](https://github.com/0xCardinal/actsense/security/code-scanning/5)

To address this, the user-supplied path (`full_path`) must be validated before using it to access files. The canonical approach is to normalize the path, then check that the file to serve is still within the intended static directory, blocking any traversal attempts. 

Specifically:
- Use `os.path.normpath(os.path.join(FRONTEND_BUILD_PATH, full_path))` to normalize the full path.
- Check that the normalized path begins with `os.path.abspath(FRONTEND_BUILD_PATH)` (using absolute paths avoids ambiguity).
- Only serve files from inside the allowed directory.
- If the check fails (meaning the user tried to escape the directory), return a 404 or appropriate error.

Edit only the route at line 403-412 (and related lines if needed), adding normalization and validation. No functionality change for legitimate requests, just extra security against traversal.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
