### PR TITLE
Potential fix for code scanning alert no. 2: Uncontrolled command line

### DIFF
--- a/backend/repo_cloner.py
+++ b/backend/repo_cloner.py
@@ -6,6 +6,7 @@ import os
 from typing import Optional, Tuple
 from pathlib import Path
 import re
+from urllib.parse import quote
 
 class RepoCloner:
     """Handle cloning and cleanup of repositories."""
@@ -47,8 +48,9 @@ class RepoCloner:
             # Additional check for forbidden characters in the token
             if any(c in token for c in '@:/\\ \n\r\t'):
                 raise ValueError("Token contains forbidden characters")
-            # For private repos, use token in URL
-            repo_url = f"https://{token}@github.com/{owner}/{repo}.git"
+            # For private repos, use token in URL. URL-encode the token to ensure safety.
+            safe_token = quote(token, safe='')
+            repo_url = f"https://{safe_token}@github.com/{owner}/{repo}.git"
         
         # Create unique directory for this clone
         clone_dir = self.base_dir / f"{owner}_{repo}_{os.getpid()}"


### PR DESCRIPTION
Potential fix for [https://github.com/0xCardinal/actsense/security/code-scanning/2](https://github.com/0xCardinal/actsense/security/code-scanning/2)

The best way to fix the problem is to treat the GitHub token strictly as URL *data*, not as a literal string to be slotted into a URL template. The token should be properly URL-encoded before adding it to the repository URL, ensuring that no forbidden or special characters can affect how the URL is parsed by `git` or how subprocessing handles it. Additionally, owner and repo should be strictly validated (can use regex or URL quoting as well, though the danger from those is less, since the object is positional and only part of the repo URL). 

**Steps to fix:**
- Import `urllib.parse.quote` (part of Python stdlib) to encode the token before placing it in the URL.
- Before using the token in the URL, apply `quote(token, safe='')` to ensure any meta-characters are percent-encoded.
- Optionally, apply similar quoting to `owner` and `repo` (using safe='') to block all but alphanumerics.
- Add an explicit comment that the token is URL-encoded, and don't rely merely on regex validation.
- These changes go to `backend/repo_cloner.py`, specifically from line 38-51.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
