### PR TITLE
fix: avoid deprecated/older-version false positives for missing actions

### DIFF
--- a/backend/rules/security.py
+++ b/backend/rules/security.py
@@ -2300,6 +2300,31 @@ async def check_older_action_versions(workflow: Dict[str, Any], client: Optional
         except Exception:
             return None
 
+    async def repository_exists(owner: Optional[str], repo: Optional[str]) -> Optional[bool]:
+        """Return repository existence when detectable, otherwise None."""
+        if not client or not owner or not repo:
+            return None
+
+        get_repo_info = getattr(client, "get_repository_info", None)
+        if not callable(get_repo_info):
+            return None
+
+        cache_key = f"{owner}/{repo}"
+        cached = repo_existence_cache.get(cache_key)
+        if cached is not None:
+            return cached
+
+        try:
+            repo_info = await get_repo_info(owner, repo)
+            exists = repo_info is not None
+            repo_existence_cache[cache_key] = exists
+            return exists
+        except Exception:
+            # Do not guess repository existence on API errors.
+            return None
+
+    repo_existence_cache: Dict[str, bool] = {}
+
     # Check each action for older versions
     for action_ref in actions_used:
         if "@" not in action_ref:
@@ -2307,6 +2332,12 @@ async def check_older_action_versions(workflow: Dict[str, Any], client: Optional
 
         ref = action_ref.split("@")[-1]
         owner, repo, _, subdir = client.parse_action_reference(action_ref) if client else (None, None, None, None)
+
+        # If repository is confirmed missing, skip older-version checks.
+        # A missing repository is handled by check_missing_action_repositories.
+        repo_exists = await repository_exists(owner, repo)
+        if repo_exists is False:
+            continue
 
         # Check if it's a SHA-based reference
         if is_sha(ref):
@@ -2994,6 +3025,13 @@ async def check_deprecated_actions(workflow: Dict[str, Any], client: Optional[Gi
             else:
                 # Check for generic v1 versions (potentially deprecated)
                 if "@v1" in uses and uses not in deprecated_actions:
+                    # Don't emit generic "deprecated v1" finding when repository existence
+                    # couldn't be determined (for example, deleted/non-existent/private repos).
+                    # In those cases, check_missing_action_repositories is the source of truth.
+                    if client and action_owner and action_repo:
+                        repo_key = f"{action_owner}/{action_repo}"
+                        if checked_repos.get(repo_key) is None:
+                            continue
                     # Extract action name without version
                     action_name = uses.split("@")[0]
                     # Skip if it's a well-known action that might legitimately use v1

--- a/backend/tests/test_best_practices.py
+++ b/backend/tests/test_best_practices.py
@@ -62,6 +62,34 @@ class TestOlderActionVersions:
         older_version_issues = [i for i in issues if i.get("type") == "older_action_version"]
         if len(older_version_issues) > 0:
             assert "actsense.dev/vulnerabilities/older_action_version" in older_version_issues[0]["evidence"]["vulnerability"]
+
+    @pytest.mark.asyncio
+    async def test_missing_repository_not_flagged_as_older_version(self, mock_github_client):
+        """Missing repositories should not produce older_action_version findings."""
+        from unittest.mock import AsyncMock, MagicMock
+
+        workflow = {
+            "name": "Test Workflow",
+            "on": ["push"],
+            "jobs": {
+                "build-container": {
+                    "runs-on": "ubuntu-latest",
+                    "steps": [
+                        {"uses": "example-org/super-secure-deploy@v1"}
+                    ],
+                }
+            },
+        }
+
+        mock_github_client.parse_action_reference = MagicMock(
+            return_value=("example-org", "super-secure-deploy", None, None)
+        )
+        mock_github_client.get_repository_info = AsyncMock(return_value=None)
+        mock_github_client.get_latest_tag = AsyncMock(return_value="v3.0.0")
+
+        issues = await security_rules.check_older_action_versions(workflow, client=mock_github_client)
+        older_version_issues = [i for i in issues if i.get("type") == "older_action_version"]
+        assert len(older_version_issues) == 0
     
     def test_inconsistent_action_versions(self, workflow_with_inconsistent_versions):
         """Test detection of inconsistent action versions."""
@@ -190,6 +218,33 @@ class TestDeprecatedActions:
         deprecated_issues = [i for i in issues if i.get("type") == "deprecated_action"]
         if len(deprecated_issues) > 0:
             assert "actsense.dev/vulnerabilities/deprecated_action" in deprecated_issues[0]["evidence"]["vulnerability"]
+
+    @pytest.mark.asyncio
+    async def test_nonexistent_v1_action_not_flagged_as_deprecated(self, mock_github_client):
+        """Non-existent action repos should be handled by missing_action_repository, not deprecated_action."""
+        from unittest.mock import AsyncMock, MagicMock
+
+        workflow = {
+            "name": "Test Workflow",
+            "on": ["push"],
+            "jobs": {
+                "build-container": {
+                    "runs-on": "ubuntu-latest",
+                    "steps": [
+                        {"uses": "example-org/super-secure-deploy@v1"}
+                    ],
+                }
+            },
+        }
+
+        mock_github_client.get_repository_info = AsyncMock(return_value=None)
+        mock_github_client.parse_action_reference = MagicMock(
+            return_value=("example-org", "super-secure-deploy", "v1", None)
+        )
+
+        issues = await security_rules.check_deprecated_actions(workflow, client=mock_github_client)
+        deprecated_issues = [i for i in issues if i.get("type") == "deprecated_action"]
+        assert len(deprecated_issues) == 0
 
 
 class TestMissingActionRepositories:


### PR DESCRIPTION
Skip deprecated v1 and older-version findings when action repository existence cannot be verified so non-existent actions are reported only as missing repositories.